### PR TITLE
Provide a binary for use by package consumers

### DIFF
--- a/bin/trader-server
+++ b/bin/trader-server
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../app');

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "bin": {
+    "trader-server": "bin/trader-server"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/garethdown44/trader-server.git"


### PR DESCRIPTION
Having a binary will allow 'trader-server' to be used by other packages that want to install it as a dependency.